### PR TITLE
fix: prevent duplicate startup summaries and automate version bumping

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,25 @@ The extension maintains all its data in the `.gemini-workspace-history/` directo
 - **Context Injection:** The `gemini-extension.json` manifest is configured with `contextFileName: ".gemini-workspace-history/active-context.md"`, which the CLI uses to automatically include the file in every session.
 - **Hooks Configuration:** Lifecycle hooks are managed via `hooks/hooks.json`.
 - **Skills:** Includes the `workspace-summarizer` skill to help maintain session continuity.
+
+## Development
+
+### Running Tests
+
+To verify the extension's functionality and path resolution:
+
+```bash
+npm test
+```
+
+### Version Management
+
+The project uses a strict versioning policy. Every PR must include a version bump, which is verified by the automated test suite.
+
+To increment the patch version based on the latest git tag:
+
+```bash
+npm run bump
+```
+
+This command will update both `package.json` and `gemini-extension.json` to the next patch version (e.g., `0.1.2` -> `0.1.3`).

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "workspace-history",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "contextFileName": ".gemini-workspace-history/active-context.md",
   "skills": [
     {

--- a/hooks/on-start.js
+++ b/hooks/on-start.js
@@ -81,9 +81,7 @@ async function main() {
         fs.writeFileSync(activeContextPath, systemMessage);
     }
 
-    process.stdout.write(JSON.stringify({
-        systemMessage: systemMessage
-    }));
+    process.stdout.write(JSON.stringify({}));
 }
 
 main().catch(console.error);

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Workspace-specific session history and summaries for Gemini CLI",
   "type": "module",
   "scripts": {
-    "test": "node --test"
+    "test": "node --test",
+    "bump": "node scripts/bump-version.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini-workspace-history",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Workspace-specific session history and summaries for Gemini CLI",
   "type": "module",
   "scripts": {

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+import fs from 'fs';
+import path from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = path.resolve(__dirname, '..');
+
+function getLatestTag() {
+    const result = spawnSync('git', ['tag', '-l', 'v*'], { encoding: 'utf8' });
+    const tags = result.stdout.trim().split('\n').filter(t => /^v\d+\.\d+(\.\d+)?$/.test(t));
+    
+    if (tags.length === 0) return 'v0.0.0';
+
+    return tags.sort((a, b) => {
+        const partsA = a.substring(1).split('.').map(Number);
+        const partsB = b.substring(1).split('.').map(Number);
+        for (let i = 0; i < 3; i++) {
+            const va = partsA[i] || 0;
+            const vb = partsB[i] || 0;
+            if (va !== vb) return vb - va;
+        }
+        return 0;
+    })[0];
+}
+
+function bumpPatch(version) {
+    const parts = version.substring(1).split('.').map(Number);
+    while (parts.length < 3) parts.push(0);
+    parts[2]++;
+    return parts.join('.');
+}
+
+const latestTag = getLatestTag();
+const newVersion = bumpPatch(latestTag);
+
+console.log(`Bumping from ${latestTag} to ${newVersion}`);
+
+// Update JSON files safely
+[
+    path.join(ROOT_DIR, 'package.json'),
+    path.join(ROOT_DIR, 'gemini-extension.json')
+].forEach(filePath => {
+    if (fs.existsSync(filePath)) {
+        const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+        data.version = newVersion;
+        fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + '\n');
+        console.log(`Updated ${path.basename(filePath)}`);
+    }
+});

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Get the latest tag matching v*
+LATEST_TAG=$(git tag -l "v*" | sort -V | tail -n1)
+
+if [ -z "$LATEST_TAG" ]; then
+    echo "No tags found, starting from v0.0.0"
+    LATEST_TAG="v0.0.0"
+fi
+
+echo "Latest tag found: $LATEST_TAG"
+
+# Remove the 'v' prefix
+VERSION=${LATEST_TAG#v}
+
+# Split version into parts
+IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+
+# Ensure patch is treated as a number
+PATCH=${PATCH:-0}
+
+# Bump patch ONLY
+NEW_PATCH=$((PATCH + 1))
+NEW_VERSION="$MAJOR.$MINOR.$NEW_PATCH"
+
+echo "New version (patch bump): $NEW_VERSION"
+
+# Update package.json using sed
+sed -i "s/\"version\": \".*\"/\"version\": \"$NEW_VERSION\"/" package.json
+
+# Update gemini-extension.json
+sed -i "s/\"version\": \".*\"/\"version\": \"$NEW_VERSION\"/" gemini-extension.json
+
+echo "Updated package.json and gemini-extension.json"

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -35,6 +35,10 @@ test('Hooks save to payload cwd, not process cwd', async (t) => {
     assert.strictEqual(startResult.status, 0, 'on-start.js should exit with status 0');
     assert.ok(fs.existsSync(historyDir), 'HISTORY_DIR should be created in payload cwd by on-start.js');
     assert.ok(fs.existsSync(path.join(historyDir, 'active-context.md')), 'active-context.md should be created');
+
+    // 3.1 Verify empty output to prevent duplicate summaries
+    const startOutput = JSON.parse(startResult.stdout);
+    assert.deepStrictEqual(startOutput, {}, 'on-start.js should return an empty object to prevent duplicate summaries');
     
     // 4. Test on-end.js
     const endResult = spawnSync('node', [path.join(ROOT_DIR, 'hooks', 'on-end.js')], {
@@ -50,6 +54,13 @@ test('Hooks save to payload cwd, not process cwd', async (t) => {
 
     // Cleanup
     fs.rmSync(tempWorkspace, { recursive: true, force: true });
+});
+
+test('Version consistency', (t) => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(ROOT_DIR, 'package.json'), 'utf8'));
+    const ext = JSON.parse(fs.readFileSync(path.join(ROOT_DIR, 'gemini-extension.json'), 'utf8'));
+    
+    assert.strictEqual(pkg.version, ext.version, 'package.json and gemini-extension.json versions should match');
 });
 
 test('on-start.js fallback to process.cwd() when stdin is empty', async (t) => {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -63,6 +63,39 @@ test('Version consistency', (t) => {
     assert.strictEqual(pkg.version, ext.version, 'package.json and gemini-extension.json versions should match');
 });
 
+test('Version must be greater than on main', (t) => {
+    try {
+        const mainPkgRaw = spawnSync('git', ['show', 'main:package.json'], { encoding: 'utf8' }).stdout;
+        if (!mainPkgRaw) {
+            console.log('Skipping version check: main:package.json not found');
+            return;
+        }
+        const mainPkg = JSON.parse(mainPkgRaw);
+        const currentPkg = JSON.parse(fs.readFileSync(path.join(ROOT_DIR, 'package.json'), 'utf8'));
+
+        const vCurrent = currentPkg.version.split('.').map(Number);
+        const vMain = mainPkg.version.split('.').map(Number);
+
+        let isGreater = false;
+        if (vCurrent[0] > vMain[0]) {
+            isGreater = true;
+        } else if (vCurrent[0] === vMain[0]) {
+            if (vCurrent[1] > vMain[1]) {
+                isGreater = true;
+            } else if (vCurrent[1] === vMain[1]) {
+                if (vCurrent[2] > vMain[2]) {
+                    isGreater = true;
+                }
+            }
+        }
+
+        assert.ok(isGreater, `Current version (${currentPkg.version}) must be strictly greater than main version (${mainPkg.version})`);
+    } catch (e) {
+        if (e.message.includes('must be strictly greater')) throw e;
+        console.log('Skipping version check (likely no main branch yet): ', e.message);
+    }
+});
+
 test('on-start.js fallback to process.cwd() when stdin is empty', async (t) => {
     const tempWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), 'gemini-fallback-test-'));
     const historyDir = path.join(tempWorkspace, '.gemini-workspace-history');


### PR DESCRIPTION
  **Overview**
  This PR addresses the issue of duplicate summaries appearing at the start of a session and introduces automated version management.

  **Changes**
   - Duplicate Summary Fix: Modified hooks/on-start.js to stop returning a systemMessage, as the Gemini CLI already loads this content from .gemini-workspace-history/active-context.md.
   - Automated Versioning: Added scripts/bump-version.sh to automate patch version increments based on existing git tags.
   - Enhanced Testing:
       - Added a test to verify that the startup hook's JSON output is empty to prevent future regressions.
       - Added a consistency check between package.json and gemini-extension.json.
       - Enforced a strict versioning rule: the current version must be greater than the version on the main branch.
